### PR TITLE
Add ansible docker images

### DIFF
--- a/ansible/Dockerfile
+++ b/ansible/Dockerfile
@@ -2,8 +2,8 @@ FROM python:2.7-alpine
 
 MAINTAINER Nic Henke <nic.henke@versity.com>
 
-RUN apk add --no-cache --virtual .build-deps gcc libc-dev libffi-dev openssl-dev && \
-    apk add --no-cache --virtual .run-deps git && \
+RUN apk add --no-cache --virtual .run-deps git bash openssh libffi rsync && \
+    apk add --no-cache --virtual .build-deps gcc libc-dev libffi-dev openssl-dev && \
     pip install -U --no-cache-dir pip && \
     # Ansible & requirements
     pip install --no-cache-dir ansible simplejson netaddr && \

--- a/ansible/Dockerfile
+++ b/ansible/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:2.7-alpine
+
+MAINTAINER Nic Henke <nic.henke@versity.com>
+
+RUN apk add --no-cache --virtual .build-deps gcc libc-dev libffi-dev openssl-dev && \
+    apk add --no-cache --virtual .run-deps git && \
+    pip install -U --no-cache-dir pip && \
+    # Ansible & requirements
+    pip install --no-cache-dir ansible simplejson netaddr && \
+    apk del .build-deps && \
+    rm -fr ~/.cache
+
+# we run ansible-playbook, go go go
+ENTRYPOINT ["/usr/local/bin/ansible-playbook"]
+CMD ["--help"]

--- a/ansible/onbuild/Dockerfile
+++ b/ansible/onbuild/Dockerfile
@@ -1,0 +1,16 @@
+FROM versity-ansible:2
+
+MAINTAINER Nic Henke <nic.henke@versity.com>
+
+# setup requirements.yml needed from local source dir
+
+RUN mkdir /src
+# setup /src to allow for role installs or anything else we'll need there later
+VOLUME /src
+
+ONBUILD ADD ansible.cfg requirements.yml /src/
+ONBUILD RUN (cd /src; ansible-galaxy install -r ./requirements.yml --force)
+
+# TODO
+# - add a fact with version of image, so ansible role code can assert on that later
+#  -- allowing us to version the images & role codes sensibly


### PR DESCRIPTION
These are the first two ansible docker images.

- A base image for running ansible
- An onbuild image that can be used by projects to get a docker image
with their requirements.yml installed.