### PR TITLE
Rebase images onto Centos

### DIFF
--- a/python/2.7/Dockerfile
+++ b/python/2.7/Dockerfile
@@ -1,10 +1,10 @@
-FROM python:2.7-alpine
+FROM centos:7
 
 MAINTAINER Nic Henke <nic.henke@versity.com>
 
 # hack for helping us getting going with docker, bash lets us get in and see what isn't working
-RUN apk add --no-cache --virtual .removebeforeshipping bash
-
-RUN pip install -U --no-cache-dir pip setuptools && rm -fr ~/.cache
+RUN yum install -y bash python-setuptools && yum clean all && \
+    easy_install pip && \
+    pip install -U --no-cache-dir pip setuptools && rm -fr ~/.cache && rm -fr /var/cache/*
 
 CMD ["python2"]

--- a/python/2.7/devel/Dockerfile
+++ b/python/2.7/devel/Dockerfile
@@ -4,12 +4,13 @@ MAINTAINER Nic Henke <nic.henke@versity.com>
 
 # the first few layers to keep around...
 # git & openssh for pip installs and builds
-RUN apk add --no-cache --virtual .dev-deps man man-pages git openssh
-
-# we need gcc and friends to build cython modules
-# attr* for xfs-python and panorama
-# linux-headers for just about everyone itseems
-RUN apk add --no-cache --virtual .run-deps gcc libc-dev attr attr-dev linux-headers
+RUN yum install -y man man-pages git openssh && \
+    # we need gcc and friends to build cython modules
+    # attr* for xfs-python and panorama
+    # linux-headers for just about everyone itseems
+    yum install -y gcc glibc-devel python-devel && \
+    yum install -y xfsprogs xfsprogs-devel libattr libattr-devel kernel-headers && \
+    yum clean all && rm -fr /var/cache/*
 
 # Install basic Python tools
 RUN pip2.7 install --no-cache-dir -U cython tox pylint pytest pytest-cov pytest-catchlog wheel && rm -fr ~/.cache


### PR DESCRIPTION
Using Alpine linux turned out to be a bad idea once we were using it to
generate compiled.so. Our own versity.xfs and then wheel'ing netifaces
would generate libc symbol messes.

Generating the wheels and .so on Centos and running on Alpine is
similarity messy - glibc isn't available on Alpine and we end up with
missing symbols too.

This is fully tested - building versity.xfs, testing versity.panorama on
mac, building docker for versity.panorama and wheels on mac, running
said bits on a real Linux node.