### PR TITLE
Avoid pycparser 2.15

### DIFF
--- a/ansible/Dockerfile
+++ b/ansible/Dockerfile
@@ -5,6 +5,10 @@ MAINTAINER Nic Henke <nic.henke@versity.com>
 RUN apk add --no-cache --virtual .run-deps git bash openssh libffi rsync && \
     apk add --no-cache --virtual .build-deps gcc libc-dev libffi-dev openssl-dev && \
     pip install -U --no-cache-dir pip && \
+    # pycparser has a bug in 2.15,
+    # - cryptography - https://github.com/pyca/cryptography/issues/3187
+    # - pycparser - https://github.com/eliben/pycparser/issues/151
+    pip install pycparser==2.14 && \
     # Ansible & requirements
     pip install --no-cache-dir ansible simplejson netaddr && \
     apk del .build-deps && \


### PR DESCRIPTION
There is an upstream bug that is causing cryptography builds to fail.
The suggested workaround is to lock to older versions until the issue is
resolved.