### PR TITLE
Add docs for some of our installed packages.

### DIFF
--- a/python/2.7/devel/Dockerfile
+++ b/python/2.7/devel/Dockerfile
@@ -4,12 +4,14 @@ MAINTAINER Nic Henke <nic.henke@versity.com>
 
 # the first few layers to keep around...
 # git & openssh for pip installs and builds
-RUN yum install -y man man-pages git openssh && \
+# - note tsflags=nodocs by default, there are actually some docs we want!
+RUN yum --setopt tsflags='' install -y man man-pages git openssh && \
     # we need gcc and friends to build cython modules
     # attr* for xfs-python and panorama
     # linux-headers for just about everyone itseems
-    yum install -y gcc glibc-devel python-devel && \
-    yum install -y xfsprogs xfsprogs-devel libattr libattr-devel kernel-headers && \
+    yum install -y gcc glibc-devel && \
+    yum --setopt tsflags='' install -y python-devel && \
+    yum --setopt tsflags='' install -y xfsprogs xfsprogs-devel libattr libattr-devel kernel-headers && \
     yum clean all && rm -fr /var/cache/*
 
 # Install basic Python tools


### PR DESCRIPTION
By default, the upstream centos image has a yum.conf with
'tsflags=nodocs' to help keep the image size down. Since this is our
devel image, we need docs to allow easy access to man pages, etc.

We manually set tsflags for some of the installs. If we find holes in
the docs we want, we can roll back the entire yum.conf setting and add
those in. I'm doing a targeted fix now to keep the image size somewhat
sane.

This adds ~25MB to the -devel image, tested with 'man 2 open' and 'man
open_by_handle'.

Do note, you will need to rebuild with the following, as the tsflags
update to the Dockerfile doesn't trigger a full rebuild it seems.

docker build --no-cache -t versity-python:2.7-devel .
