### PR TITLE
Add sshpass for ansible bootstraps

### DIFF
--- a/ansible/Dockerfile
+++ b/ansible/Dockerfile
@@ -4,6 +4,8 @@ MAINTAINER Nic Henke <nic.henke@versity.com>
 
 RUN apk add --no-cache --virtual .run-deps git bash openssh libffi rsync && \
     apk add --no-cache --virtual .build-deps gcc libc-dev libffi-dev openssl-dev && \
+    # Add sshpass for ansible bootstrap where we need to use ansible-playbook -k/-K
+    apk add --no-cache sshpass --virtual .ansible-deps && \
     pip install -U --no-cache-dir pip && \
     # pycparser has a bug in 2.15,
     # - cryptography - https://github.com/pyca/cryptography/issues/3187


### PR DESCRIPTION
When running ansible bootstrapping, we need to pass in the password
manually. This addition of sshpass to the docker image is required for
ansible to be able to ask for those passwords.