### PR TITLE
Use Docker Hub for image repository

### DIFF
--- a/ansible/onbuild/Dockerfile
+++ b/ansible/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM versity-ansible:2
+FROM versity/ansible:2
 
 MAINTAINER Nic Henke <nic.henke@versity.com>
 

--- a/build_all.sh
+++ b/build_all.sh
@@ -2,21 +2,36 @@
 
 set -ex
 
+# NOTE: using push requires the user to have first done a 'docker login' to authenticate with
+# docker.io (Docker Hub)
+DOCKER_PUSH=${DOCKER_PUSH:-false}
+
 pushd ansible
-docker build -t versity-ansible:2 .
+docker build -t versity/ansible:2 .
+if $DOCKER_PUSH; then
+    docker push versity/ansible:2
+fi
 
 pushd onbuild
-docker build -t versity-ansible:2-onbuild .
+docker build -t versity/ansible:2-onbuild .
+if $DOCKER_PUSH; then
+    docker push versity/ansible:2-onbuild
+fi
 
 popd
 popd
 
 for pyv in "2.7" "3.6"; do
     pushd "python/$pyv"
-    docker build -t "versity-python:$pyv" .
+    docker build -t "versity/python:$pyv" .
 
     pushd devel
-    docker build -t "versity-python:$pyv-devel" .
+    docker build -t "versity/python:$pyv-devel" .
+
+    if $DOCKER_PUSH; then
+        docker push "versity/python:$pyv"
+        docker push "versity/python:$pyv-devel"
+    fi
 
     popd; popd
 done

--- a/python/2.7/devel/Dockerfile
+++ b/python/2.7/devel/Dockerfile
@@ -1,4 +1,4 @@
-FROM versity-python:2.7
+FROM versity/python:2.7
 
 MAINTAINER Nic Henke <nic.henke@versity.com>
 

--- a/python/3.6/devel/Dockerfile
+++ b/python/3.6/devel/Dockerfile
@@ -1,4 +1,4 @@
-FROM versity-python:3.6
+FROM versity/python:3.6
 
 MAINTAINER Nic Henke <nic.henke@versity.com>
 


### PR DESCRIPTION
To allow for us having network access to our base image for Ansible and
Python, we'll push them to Docker Hub. A bit of renaming was necessary
to conform to the normal docker team/repository scheme.

The current images have been pushed.

These images do not contain anything sensitive, so pushing upstream is
OK. Cleared public company visibility with CEO too.