### PR TITLE
Create docker image for building libarchive

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -35,3 +35,8 @@ for pyv in "2.7" "3.6"; do
 
     popd; popd
 done
+
+pushd libarchive
+docker build -t "versity/libarchive:c7-build" .
+docker push "versity/libarchive:c7-build"
+popd

--- a/libarchive/Dockerfile
+++ b/libarchive/Dockerfile
@@ -1,0 +1,12 @@
+FROM centos:7
+
+MAINTAINER Nic Henke <nic.henke@versity.com>
+
+# Packages needed to build libarchive from source, including a few utilities to help with debugging
+RUN yum install -y which less bash gcc libattr libattr-devel libacl libacl-devel bzip2-devel \
+                   cmake bzip2 libz-devel openssl-devel libxml2 libxml2-devel xz-devel make \
+                   lz4 lz4-devel man man-pages gdb file && \
+    yum clean all && \
+    rm -fr ~/.cache && rm -fr /var/cache/*
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
The build requirements for libarchive are a bit hard to find, so we'll use a docker container to help record and distribute those.