### PR TITLE
Reduce libarchive build requirements

### DIFF
--- a/libarchive/Dockerfile
+++ b/libarchive/Dockerfile
@@ -3,9 +3,11 @@ FROM centos:7
 MAINTAINER Nic Henke <nic.henke@versity.com>
 
 # Packages needed to build libarchive from source, including a few utilities to help with debugging
-RUN yum install -y which less bash gcc libattr libattr-devel libacl libacl-devel bzip2-devel \
-                   cmake bzip2 libz-devel openssl-devel libxml2 libxml2-devel xz-devel make \
-                   lz4 lz4-devel man man-pages gdb file && \
+RUN yum install -y which less file man man-pages bash gdb \
+                   make cmake gcc libattr libacl ghostscript zip && \
+    pushd /var/cache && yumdownloader --source libarchive && \
+    yum-builddep -y ./libarchive*.src.rpm && \
+    popd && \
     yum clean all && \
     rm -fr ~/.cache && rm -fr /var/cache/*
 


### PR DESCRIPTION
This refactors the list of build requirements down to the minimum needed
to build libarchive RPMs in Docker. We need a few extra packages for
things the system needs to run in creating the source RPM. Finally we
pull down the upstream libarchive src.rpm and make sure we have all of
the BuildRequires installed.