### PR TITLE
Build ansible docker images with travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: bash
+services: docker
+
+env:
+  global:
+    - HUB_REPO=versity
+  matrix:
+    # onbuild will happen automatically
+    - PROJECT=ansible VARIANT=
+
+before_script:
+  - env | sort
+  - cd "$PROJECT"
+  - image="$(awk '$1 == "FROM" { print $2; exit }' onbuild/Dockerfile)${VARIANT:+-$VARIANT}"
+
+script:
+  - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
+  - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, PR=$PR, BRANCH=$BRANCH"
+  - travis_retry docker build -t "$image" "${VARIANT:-.}"
+# the "onbuild" variant has to happen with the base variant because it's FROM it
+  - true && [ "$VARIANT" ] || travis_retry docker build -t "${image}-onbuild" onbuild
+
+after_script:
+  - docker images
+
+after_success:
+  - if [ "$BRANCH" == "master" ]; then
+      docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
+      docker push "$HUB_REPO/$PROJECT";
+    fi
+
+# vim:set et ts=2 sw=2:


### PR DESCRIPTION
We start off our Travis builds with creating the ansible:2 and
ansible:2-onbuild images.

The master branch will be automatically build and uploaded to our Docker
Hub account.

GitHub PRs will be updated with the results of the build.

As of yet, we are not testing the images.